### PR TITLE
[RFR] Feature/contentful lib fix

### DIFF
--- a/app/server/api/v1/api.js
+++ b/app/server/api/v1/api.js
@@ -23,7 +23,8 @@ const contentfulClient = contentful.createClient({
   space: config.contentful.contentSpace,
   environment: config.contentful.environment,
   // This is the access token for this space. Normally you get both ID and the token in the Contentful web app
-  accessToken: config.contentful.contentAccessToken
+  accessToken: config.contentful.contentAccessToken,
+  host: config.contentful.contentHost
 })
 
 /**

--- a/config.preview.yaml
+++ b/config.preview.yaml
@@ -2,7 +2,7 @@ buildConfig: production
 api: http://preview.alpha-talktofrank.cxp.io:3000
 
 contentful:
-  contentHost: 'https://preview.contentful.com'
+  contentHost: 'preview.contentful.com'
   contentSpace: 'ip74mqmfgvqf'
   contentAccessToken: !!import/single '../config.creds.yaml'
   environment: 'develop'

--- a/config.staging.yaml
+++ b/config.staging.yaml
@@ -2,7 +2,7 @@ buildConfig: production
 api: https://alpha-talktofrank.cxp.io
 ga: UA-129232-18 # @joel - update this as this is the test account
 contentful:
-  contentHost: 'https://cdn.contentful.com'
+  contentHost: 'cdn.contentful.com'
   contentSpace: 'ip74mqmfgvqf'
   contentAccessToken: !!import/single '../config.creds.yaml'
   environment: 'develop'


### PR DESCRIPTION
and another small change - switching between preview and cdn hosts in contentful required an update to the config files: for any development version you'll need to remove the 'https' from the beginning of the 'contentHost' value i.e.

```
contentful:
  contentHost: 'cdn.contentful.com'
```