### PR TITLE
[RFR] filtering 404 errors out of Sentry logging

### DIFF
--- a/app/server/api/v1/api.js
+++ b/app/server/api/v1/api.js
@@ -680,7 +680,7 @@ router.use(function (err, req, res, next) {
 
   let msg = err.message || err.stack || err.name || 'General error'
 
-  if (config.sentry.logErrors) {
+  if (config.sentry.logErrors && status !== 404) {
     Sentry.captureException(err)
   }
 

--- a/app/server/api/v1/contact.js
+++ b/app/server/api/v1/contact.js
@@ -97,7 +97,7 @@ router.use(function (err, req, res, next) {
 
   let msg = err.message || err.stack || err.name || 'General error'
 
-  if (config.sentry.logErrors) {
+  if (config.sentry.logErrors && status !== 404) {
     Sentry.captureException(err)
   }
 

--- a/app/server/contentful/webhooks.js
+++ b/app/server/contentful/webhooks.js
@@ -248,7 +248,7 @@ router.use(function (err, req, res, next) {
 
   let msg = err.message || err.stack || err.name || 'General error'
 
-  if (config.sentry.logErrors) {
+  if (config.sentry.logErrors && status !== 404) {
     Sentry.captureException(err)
   }
 

--- a/app/server/index.jsx
+++ b/app/server/index.jsx
@@ -36,7 +36,19 @@ import contentfulClient from './contentful/lib'
 const Sentry = require('@sentry/node')
 if (config.sentry.logErrors) {
   console.log(`Error logging enabled: Sentry DSN ${config.sentry.dsn}`)
-  Sentry.init({ dsn: config.sentry.dsn })
+  Sentry.init({
+    dsn: config.sentry.dsn,
+    beforeSend(event) {
+      if (event.extra &&
+        event.extra.Error &&
+        event.extra.Error.status &&
+        event.extra.Error.status === 404) {
+        // Dont send 404 errors
+        return null
+      }
+      return event
+    }
+  })
 }
 
 /*


### PR DESCRIPTION
Log requests to Sentry are going over the limit, removing 404s so that only urgent errors are logged.